### PR TITLE
Added requirements.txt to easily install dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy==1.21.2
+pip==21.2.4
+pygame==2.0.1
+setuptools==57.4.0
+wheel==0.37.0


### PR DESCRIPTION
Use `pip3 install -r requirements.txt` to install all dependencies. Can be useful for others setting up their virtual environments.